### PR TITLE
Add deletion option for journal messages

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,6 +40,12 @@ couchbase-journal {
 
   # Max batch size for messages
   max-message-batch-size = 200
+
+  # Wheather to add tombstones documents to the bucket or to acctually remove them
+  #
+  #   "true" - means a custome tombstone documented will be added to the bucket, making other journal messages as removed
+  #   "false" - means that journal messages will be actually removed from the bucket
+  tombstone = "true"
 }
 
 couchbase-snapshot-store {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,9 +41,9 @@ couchbase-journal {
   # Max batch size for messages
   max-message-batch-size = 200
 
-  # Wheather to add tombstones documents to the bucket or to acctually remove them
+  # Wheather to add tombstones documents to the bucket or to acctually remove the documents
   #
-  #   "true" - means a custome tombstone documented will be added to the bucket, making other journal messages as removed
+  #   "true" - means a deletion marker documented will be added to the bucket, marking other journal messages as removed
   #   "false" - means that journal messages will be actually removed from the bucket
   tombstone = "true"
 }

--- a/src/main/scala/akka/persistence/couchbase/CouchbasePluginConfig.scala
+++ b/src/main/scala/akka/persistence/couchbase/CouchbasePluginConfig.scala
@@ -60,6 +60,8 @@ trait CouchbaseJournalConfig extends CouchbasePluginConfig {
 
   def maxMessageBatchSize: Int
 
+  def tombstone: Boolean
+
 }
 
 class DefaultCouchbaseJournalConfig(config: Config)
@@ -69,6 +71,8 @@ class DefaultCouchbaseJournalConfig(config: Config)
   override val replayDispatcherId = config.getString("replay-dispatcher")
 
   override val maxMessageBatchSize = config.getInt("max-message-batch-size")
+
+  override val tombstone = config.getBoolean("tombstone")
 }
 
 object CouchbaseJournalConfig {

--- a/src/main/scala/akka/persistence/couchbase/journal/CouchbaseJournal.scala
+++ b/src/main/scala/akka/persistence/couchbase/journal/CouchbaseJournal.scala
@@ -21,6 +21,8 @@ class CouchbaseJournal extends AsyncWriteJournal with CouchbaseRecovery with Cou
 
   override def bucket = couchbase.journalBucket
 
+  def tombstone = couchbase.journalConfig.tombstone
+
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
 
     val serialized = messages.map(atomicWrite => Try {
@@ -73,14 +75,19 @@ class CouchbaseJournal extends AsyncWriteJournal with CouchbaseRecovery with Cou
 
       CouchbaseRecovery.replayMessages(persistenceId, 0L, toSequenceNr, Long.MaxValue) { persistent =>
         if (!toDelete.headOption.contains(persistent.sequenceNr)) {
-          toDelete = persistent.sequenceNr :: toDelete
+//          -1 because it should take into account journal message sequence number 0
+          toDelete = (persistent.sequenceNr-1) :: toDelete
         }
       }.flatMap { _ =>
         val groups = toDelete.reverse.grouped(config.maxMessageBatchSize)
         groups.foldLeft[Try[Unit]](Success({})) { case (acc, group) =>
           acc.flatMap { _ =>
-            executeBatch {
-              group.map(sequenceNr => JournalMessage(persistenceId, sequenceNr, Marker.MessageDeleted))
+            if (tombstone) {
+              executeBatch { // add tombstone document
+                group.map(sequenceNr => JournalMessage(persistenceId, sequenceNr, Marker.MessageDeleted))
+              }
+            } else { // physically remove the document
+              deleteBatch(group)
             }
           }
         }

--- a/src/main/scala/akka/persistence/couchbase/journal/CouchbaseJournal.scala
+++ b/src/main/scala/akka/persistence/couchbase/journal/CouchbaseJournal.scala
@@ -21,7 +21,7 @@ class CouchbaseJournal extends AsyncWriteJournal with CouchbaseRecovery with Cou
 
   override def bucket = couchbase.journalBucket
 
-  def tombstone = couchbase.journalConfig.tombstone
+  val tombstone = couchbase.journalConfig.tombstone
 
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
 


### PR DESCRIPTION
Making deletion marker to be optional as in some cases we may want them to be removed completely

- adding "tombstone" parameter in the config file for couchbase-journal section, this parameter can be "true" - when you what to add deletion markers instead of removing journals from the bucket, and "false" - when you acctually what the journals to be removed from the bucket

- akka.persistence.couchbase.journal.CouchbaseStatements - adding another method that will handle deletion requests to couchbase

- akka.persistence.couchbase.journal.CouchbaseJournal - modified "asyncDeleteMessagesTo" to call deletion handler when "tombstone = false"

- akka.persistence.couchbase.CouchbaseJournalConfig - modified to read the new "tombstone" parameter from the configuration